### PR TITLE
Manifest index: Keep English first

### DIFF
--- a/organisation/manifesto.md
+++ b/organisation/manifesto.md
@@ -1,4 +1,4 @@
 # Codebridge Manifesto
 
-* [In Afrikaans](manifesto-af.md)
 * [In English](manifesto-en.md)
+* [In Afrikaans](manifesto-af.md)


### PR DESCRIPTION
It makes more sense as the primary reference.